### PR TITLE
Revert erroneous ConstantScore multi: true

### DIFF
--- a/elasticsearch_dsl/query.py
+++ b/elasticsearch_dsl/query.py
@@ -179,10 +179,7 @@ class Boosting(Query):
 
 class ConstantScore(Query):
     name = 'constant_score'
-    _param_defs = {
-        'query': {'type': 'query', 'multi': True},
-        'filter': {'type': 'query', 'multi': True}
-    }
+    _param_defs = {'query': {'type': 'query'}, 'filter': {'type': 'query'}}
 
 class DisMax(Query):
     name = 'dis_max'


### PR DESCRIPTION
While in isolated conditions some users are able to submit queries to ES directly via REST with ConstantScore multi queries, it is not supported in the majority of tests performed in production systems. In newer 5.2.x releases of ElasticSearch, cannot get this working at all, and it in fact breaks any nested use of constant score queries in bool queries, which means this change is not isolate, and thus should be more throughly tested before considering doing so again.